### PR TITLE
WIP: Fixed forwardAttachment() and adding all the other cool forwarding methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-padpro",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Padpro Puppet for Wechaty",
   "directories": {
     "example": "examples"

--- a/src/manager/cache-manager.ts
+++ b/src/manager/cache-manager.ts
@@ -285,7 +285,7 @@ export class CacheManager {
    * --------------------------------
    */
 
-  private parseJSON(payload: any) {
+  private parseJSON (payload: any) {
     log.silly(PRE, `parseJSON(${payload})`)
     return JSON.parse(payload, (_, v) => {
       if (

--- a/src/manager/cache-manager.ts
+++ b/src/manager/cache-manager.ts
@@ -295,7 +295,7 @@ export class CacheManager {
         v.type === 'Buffer'   &&
         'data' in v           &&
         Array.isArray(v.data)) {
-        return new Buffer(v.data)
+        return Buffer.from(v.data)
       }
       return v
     })

--- a/src/manager/cache-manager.ts
+++ b/src/manager/cache-manager.ts
@@ -294,7 +294,8 @@ export class CacheManager {
         'type' in v           &&
         v.type === 'Buffer'   &&
         'data' in v           &&
-        Array.isArray(v.data)) {
+        Array.isArray(v.data)
+      ) {
         return Buffer.from(v.data)
       }
       return v

--- a/src/manager/cdn-manager.ts
+++ b/src/manager/cdn-manager.ts
@@ -120,6 +120,7 @@ export class CDNManager {
       log.verbose(PRE, `uploadFile() file ${fileName} not exists in cdn, upload it...`)
       const fileKey = md5(uuid.v4())
       aesKey = getAesKey()
+      log.silly(PRE, `new aesKey - ${JSON.stringify(aesKey)}`)
       const encryptedData = encryptAes(rawData, aesKey)
       const totalSize = encryptedData.length
 
@@ -171,6 +172,7 @@ export class CDNManager {
         cdnattachurl: fileid,
         aeskey: aesKey.toString('hex'),
         encryver: 1,
+        islargefilemsg: 0, // TODO: we need to test when this is not 0
       },
       type: WechatAppMessageType.Attach,
       md5: fileMd5,

--- a/src/manager/cdn-manager.ts
+++ b/src/manager/cdn-manager.ts
@@ -110,6 +110,7 @@ export class CDNManager {
       if (checkMd5Response.fileid) {
         fileid = checkMd5Response.fileid
         const fileCache = this.cacheManager.getFileCache(fileid)
+        log.silly(PRE, `fileCache ${JSON.stringify(fileCache)}, aesKey = ${fileCache && JSON.stringify(fileCache.aesKey)}`)
         if (fileCache) {
           aesKey = fileCache.aesKey
         }
@@ -157,7 +158,10 @@ export class CDNManager {
     if (!fileid) {
       throw new Error(`${PRE} uploadFile() failed, can not get fileid.`)
     }
-    return {
+
+    log.silly(PRE, `Aeskey ${JSON.stringify(aesKey.toString('hex'))}`)
+
+    const finalPayload = {
       title: fileName,
       url: '',
       appattach: {
@@ -171,6 +175,10 @@ export class CDNManager {
       type: WechatAppMessageType.Attach,
       md5: fileMd5,
     }
+
+    log.silly(PRE, JSON.stringify(finalPayload))
+
+    return finalPayload
   }
 
   public async downloadFile (

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -75,7 +75,7 @@ import {
 
   videoPayloadParser,
   voicePayloadParser,
-  generateLocationMessage,
+  // generateLocationMessage,
 }                                         from './pure-function-helpers'
 
 import {
@@ -112,7 +112,7 @@ import {
 
 import { WechatGateway } from './gateway/wechat-gateway'
 import { CDNManager } from './manager/cdn-manager'
-import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
+// import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
 
 let PADPRO_COUNTER = 0 // PuppetPadpro Instance Counter
 
@@ -1230,7 +1230,8 @@ export class PuppetPadpro extends Puppet {
     //   await this.forwardLocation(receiver, messageId)
     } else if (
       payload.type === MessageType.Attachment ||
-      payload.type === MessageType.ChatHistory
+      payload.type === MessageType.ChatHistory ||
+      payload.type === MessageType.MiniProgram
     ) {
       await this.forwardAttachment(receiver, messageId)
     } else {

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -75,7 +75,7 @@ import {
 
   videoPayloadParser,
   voicePayloadParser,
-  // generateLocationMessage,
+  generateLocationMessage,
 }                                         from './pure-function-helpers'
 
 import {
@@ -112,7 +112,7 @@ import {
 
 import { WechatGateway } from './gateway/wechat-gateway'
 import { CDNManager } from './manager/cdn-manager'
-// import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
+import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
 
 let PADPRO_COUNTER = 0 // PuppetPadpro Instance Counter
 
@@ -1230,8 +1230,7 @@ export class PuppetPadpro extends Puppet {
     //   await this.forwardLocation(receiver, messageId)
     } else if (
       payload.type === MessageType.Attachment ||
-      payload.type === MessageType.ChatHistory ||
-      payload.type === MessageType.MiniProgram
+      payload.type === MessageType.ChatHistory
     ) {
       await this.forwardAttachment(receiver, messageId)
     } else {

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -1222,6 +1222,8 @@ export class PuppetPadpro extends Puppet {
       )
     } else if (payload.type === MessageType.Video) {
       await this.forwardVideo(receiver, messageId)
+    } else if (payload.type === MessageType.Attachment) {
+      await this.forwardAttachment(receiver, messageId)
     } else {
       await this.messageSendFile(
         receiver,
@@ -1230,30 +1232,34 @@ export class PuppetPadpro extends Puppet {
     }
   }
 
-  // private async forwardAttachment (
-  //   receiver: Receiver,
-  //   messageId: string,
-  // ): Promise<void> {
-  //   if (!this.padproManager) {
-  //     throw new Error('no padpro manager')
-  //   }
+  private async forwardAttachment (
+    receiver: Receiver,
+    messageId: string,
+  ): Promise<void> {
+    if (!this.padproManager) {
+      throw new Error('no padpro manager')
+    }
 
-  //   const rawPayload = await this.messageRawPayload(messageId)
+    const rawPayload = await this.messageRawPayload(messageId)
 
-  //   // Send to the Room if there's a roomId
-  //   const id = receiver.roomId || receiver.contactId
+    // Send to the Room if there's a roomId
+    const id = receiver.roomId || receiver.contactId
 
-  //   if (!id) {
-  //     throw new Error('There is no receiver id when trying to forward attachment.')
-  //   }
-  //   const appPayload = await appMessageParser(rawPayload)
-  //   if (appPayload === null) {
-  //     throw new Error('Can not forward attachment, failed to parse xml message.')
-  //   }
+    if (!id) {
+      throw new Error('There is no receiver id when trying to forward attachment.')
+    }
+    const appPayload = await appMessageParser(rawPayload)
+    if (appPayload === null) {
+      throw new Error('Can not forward attachment, failed to parse xml message.')
+    }
 
-  //   const content = generateAttachmentXMLMessageFromRaw(appPayload)
-  //   await this.padproManager.GrpcSendApp(id, content)
-  // }
+    appPayload.fromusername = this.selfId()
+
+    log.silly(PRE, `forwardAttachment(${JSON.stringify(appPayload)})`)
+
+    const content = generateAttachmentXMLMessageFromRaw(appPayload)
+    await this.padproManager.GrpcSendApp(id, content)
+  }
 
   private async forwardVideo (
     receiver: Receiver,

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -1218,8 +1218,6 @@ export class PuppetPadpro extends Puppet {
         receiver,
         await this.messageUrl(messageId)
       )
-    } else if (payload.type === MessageType.Attachment) {
-      await this.forwardAttachment(receiver, messageId)
     } else if (payload.type === MessageType.Video) {
       await this.forwardVideo(receiver, messageId)
     } else {

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -1216,13 +1216,17 @@ export class PuppetPadpro extends Puppet {
         GrpcVoiceFormat.Silk,
       )
     } else if (payload.type === MessageType.Url) {
+      // TODO: currently this strips out the app information
       await this.messageSendUrl(
         receiver,
         await this.messageUrl(messageId)
       )
     } else if (payload.type === MessageType.Video) {
       await this.forwardVideo(receiver, messageId)
-    } else if (payload.type === MessageType.Attachment) {
+    } else if (
+      payload.type === MessageType.Attachment ||
+      payload.type === MessageType.ChatHistory
+    ) {
       await this.forwardAttachment(receiver, messageId)
     } else {
       await this.messageSendFile(

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -1225,8 +1225,9 @@ export class PuppetPadpro extends Puppet {
       )
     } else if (payload.type === MessageType.Video) {
       await this.forwardVideo(receiver, messageId)
-    } else if (payload.type === MessageType.Location) {
-      await this.forwardLocation(receiver, messageId)
+    // commenting this out because currently there is no way to directly send location
+    // } else if (payload.type === MessageType.Location) {
+    //   await this.forwardLocation(receiver, messageId)
     } else if (
       payload.type === MessageType.Attachment ||
       payload.type === MessageType.ChatHistory
@@ -1240,34 +1241,35 @@ export class PuppetPadpro extends Puppet {
     }
   }
 
-  private async forwardLocation (
-    receiver: Receiver,
-    messageId: string,
-  ): Promise<void> {
-    if (!this.padproManager) {
-      throw new Error('no padpro manager')
-    }
+  // commenting this out because currently there is no way to directly send location
+  // private async forwardLocation (
+  //   receiver: Receiver,
+  //   messageId: string,
+  // ): Promise<void> {
+  //   if (!this.padproManager) {
+  //     throw new Error('no padpro manager')
+  //   }
 
-    const rawPayload = await this.messageRawPayload(messageId)
+  //   const rawPayload = await this.messageRawPayload(messageId)
 
-    // Send to the Room if there's a roomId
-    const id = receiver.roomId || receiver.contactId
+  //   // Send to the Room if there's a roomId
+  //   const id = receiver.roomId || receiver.contactId
 
-    if (!id) {
-      throw new Error('There is no receiver id when trying to forward location.')
-    }
-    const locationPayload = await locationPayloadParser(rawPayload)
-    if (locationPayload === null) {
-      throw new Error('Can not forward location, failed to parse xml message.')
-    }
+  //   if (!id) {
+  //     throw new Error('There is no receiver id when trying to forward location.')
+  //   }
+  //   const locationPayload = await locationPayloadParser(rawPayload)
+  //   if (locationPayload === null) {
+  //     throw new Error('Can not forward location, failed to parse xml message.')
+  //   }
 
-    locationPayload.fromUsername = this.selfId()
+  //   locationPayload.fromUsername = this.selfId()
 
-    log.silly(PRE, `forwardLocation(${JSON.stringify(locationPayload)})`)
+  //   log.silly(PRE, `forwardLocation(${JSON.stringify(locationPayload)})`)
 
-    const content = generateLocationMessage(locationPayload)
-    await this.padproManager.GrpcSendApp(id, content)
-  }
+  //   const content = generateLocationMessage(locationPayload)
+  //   await this.padproManager.GrpcSendApp(id, content)
+  // }
 
   private async forwardAttachment (
     receiver: Receiver,

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -75,7 +75,7 @@ import {
 
   videoPayloadParser,
   voicePayloadParser,
-  generateLocationMessage,
+  // generateLocationMessage,
 }                                         from './pure-function-helpers'
 
 import {
@@ -112,7 +112,7 @@ import {
 
 import { WechatGateway } from './gateway/wechat-gateway'
 import { CDNManager } from './manager/cdn-manager'
-import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
+// import { locationPayloadParser } from './pure-function-helpers/message-location-payload-parser';
 
 let PADPRO_COUNTER = 0 // PuppetPadpro Instance Counter
 
@@ -1292,7 +1292,7 @@ export class PuppetPadpro extends Puppet {
       throw new Error('Can not forward attachment, failed to parse xml message.')
     }
 
-    appPayload.fromusername = this.selfId()
+    // appPayload.fromusername = this.selfId()
 
     log.silly(PRE, `forwardAttachment(${JSON.stringify(appPayload)})`)
 

--- a/src/puppet-padpro.ts
+++ b/src/puppet-padpro.ts
@@ -832,7 +832,7 @@ export class PuppetPadpro extends Puppet {
    *
    */
   public async messageFile (messageId: string): Promise<FileBox> {
-    log.warn(PRE, 'messageFile(%s)', messageId)
+    log.silly(PRE, 'messageFile(%s)', messageId)
 
     if (!this.padproManager) {
       throw new Error('no padpro manager')
@@ -849,7 +849,7 @@ export class PuppetPadpro extends Puppet {
       case MessageType.Audio:
         const voicePayload = await voicePayloadParser(rawPayload)
         if (voicePayload === null) {
-          log.error(PRE, `Can not parse image message, content: ${rawPayload.content}`)
+          log.error(PRE, `Can not parse voice message, content: ${rawPayload.content}`)
           return FileBox.fromBase64('', filename)
         }
         const name = `${rawPayload.messageId}.${voicePayload.voiceLength}.slk`
@@ -934,8 +934,10 @@ export class PuppetPadpro extends Puppet {
           CDNFileType.ATTACHMENT,
         )
 
-        return FileBox.fromBase64(
-          data.toString('base64'),
+        log.silly(PRE, `downloaded attachment ${filename} - ${data.byteLength} bytes`)
+
+        return FileBox.fromBuffer(
+          data,
           filename,
         )
 
@@ -1228,30 +1230,30 @@ export class PuppetPadpro extends Puppet {
     }
   }
 
-  private async forwardAttachment (
-    receiver: Receiver,
-    messageId: string,
-  ): Promise<void> {
-    if (!this.padproManager) {
-      throw new Error('no padpro manager')
-    }
+  // private async forwardAttachment (
+  //   receiver: Receiver,
+  //   messageId: string,
+  // ): Promise<void> {
+  //   if (!this.padproManager) {
+  //     throw new Error('no padpro manager')
+  //   }
 
-    const rawPayload = await this.messageRawPayload(messageId)
+  //   const rawPayload = await this.messageRawPayload(messageId)
 
-    // Send to the Room if there's a roomId
-    const id = receiver.roomId || receiver.contactId
+  //   // Send to the Room if there's a roomId
+  //   const id = receiver.roomId || receiver.contactId
 
-    if (!id) {
-      throw new Error('There is no receiver id when trying to forward attachment.')
-    }
-    const appPayload = await appMessageParser(rawPayload)
-    if (appPayload === null) {
-      throw new Error('Can not forward attachment, failed to parse xml message.')
-    }
+  //   if (!id) {
+  //     throw new Error('There is no receiver id when trying to forward attachment.')
+  //   }
+  //   const appPayload = await appMessageParser(rawPayload)
+  //   if (appPayload === null) {
+  //     throw new Error('Can not forward attachment, failed to parse xml message.')
+  //   }
 
-    const content = generateAttachmentXMLMessageFromRaw(appPayload)
-    await this.padproManager.GrpcSendApp(id, content)
-  }
+  //   const content = generateAttachmentXMLMessageFromRaw(appPayload)
+  //   await this.padproManager.GrpcSendApp(id, content)
+  // }
 
   private async forwardVideo (
     receiver: Receiver,

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -30,7 +30,7 @@ export const generateAppXMLMessage = ({ title, description, url, thumbnailUrl }:
 
 export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePayload): string => {
   return `
-	<appmsg appid="" sdkver="0">
+	<appmsg appid="${payload.$appid}" sdkver="0">
 		<title>${payload.title}</title>
 		<des></des>
 		<username />
@@ -59,6 +59,11 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 		<appattach>
 			<attachid>${payload.appattach && payload.appattach.attachid}</attachid>
 			<cdnattachurl>${payload.appattach && payload.appattach.cdnattachurl}</cdnattachurl>
+			<cdnthumburl>${payload.appattach && payload.appattach.cdnthumburl}</cdnthumburl>
+			<cdnthumblength>${payload.appattach && payload.appattach.cdnthumblength}</cdnthumblength>
+			<cdnthumbwidth>${payload.appattach && payload.appattach.cdnthumbwidth}</cdnthumbwidth>
+			<cdnthumbheight>${payload.appattach && payload.appattach.cdnthumbheight}</cdnthumbheight>
+			<cdnthumbaeskey>${payload.appattach && payload.appattach.cdnthumbaeskey}</cdnthumbaeskey>
 			<totallen>${payload.appattach && payload.appattach.totallen}</totallen>
 			<aeskey>${payload.appattach && payload.appattach.aeskey}</aeskey>
 			<encryver>${payload.appattach && payload.appattach.encryver}</encryver>
@@ -100,9 +105,16 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 		<template_id />
 		<md5>${payload.md5 || ''}</md5>
 		<weappinfo>
-			<username />
-			<appid />
+			<username><![CDATA[${payload.weappinfo && payload.weappinfo.username}]]</username>
+			<appid><![CDATA[${payload.weappinfo && payload.weappinfo.appid}]]</appid>
+			<pagepath><![CDATA[${payload.weappinfo && payload.weappinfo.pagepath}]]</pagepath>
+			<version>${payload.weappinfo && payload.weappinfo.version}</version>
+			<weappiconurl><![CDATA[${payload.weappinfo && payload.weappinfo.weappiconurl}]]</weappiconurl>
 			<appservicetype>0</appservicetype>
+			<pkginfo>
+				<type>${payload.weappinfo && payload.weappinfo.pkginfo && payload.weappinfo.pkginfo.type}</type>
+				<md5><![CDATA[${payload.weappinfo && payload.weappinfo.pkginfo && payload.weappinfo.pkginfo.md5}]]></md5>
+			</pkginfo>
 			<videopageinfo>
 				<thumbwidth>0</thumbwidth>
 				<thumbheight>0</thumbheight>
@@ -119,8 +131,8 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 	<fromusername>${payload.fromusername}</fromusername>
 	<scene>0</scene>
 	<appinfo>
-		<version>1</version>
-		<appname></appname>
+		<version>${payload.appinfo && payload.appinfo.version || '1'}</version>
+		<appname>${payload.appinfo && payload.appinfo.appname}</appname>
 	</appinfo>
 	<commenturl></commenturl>`
 }

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -1,5 +1,5 @@
 import { UrlLinkPayload } from 'wechaty-puppet'
-import { PadproAppMessagePayload, WechatAppMessageType, PadproLocationMessagePayload } from '../schemas'
+import { PadproAppMessagePayload, PadproLocationMessagePayload, WechatAppMessageType } from '../schemas'
 
 export const generateLocationMessage = (payload: PadproLocationMessagePayload): string => {
   return `<location x="${payload.x || ''}"` +

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -30,7 +30,7 @@ export const generateAppXMLMessage = ({ title, description, url, thumbnailUrl }:
 
 export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePayload): string => {
   return `
-	<appmsg appid="${payload.$appid}" sdkver="0">
+	<appmsg appid="" sdkver="0">
 		<title>${payload.title}</title>
 		<des></des>
 		<username />
@@ -59,11 +59,6 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 		<appattach>
 			<attachid>${payload.appattach && payload.appattach.attachid}</attachid>
 			<cdnattachurl>${payload.appattach && payload.appattach.cdnattachurl}</cdnattachurl>
-			<cdnthumburl>${payload.appattach && payload.appattach.cdnthumburl}</cdnthumburl>
-			<cdnthumblength>${payload.appattach && payload.appattach.cdnthumblength}</cdnthumblength>
-			<cdnthumbwidth>${payload.appattach && payload.appattach.cdnthumbwidth}</cdnthumbwidth>
-			<cdnthumbheight>${payload.appattach && payload.appattach.cdnthumbheight}</cdnthumbheight>
-			<cdnthumbaeskey>${payload.appattach && payload.appattach.cdnthumbaeskey}</cdnthumbaeskey>
 			<totallen>${payload.appattach && payload.appattach.totallen}</totallen>
 			<aeskey>${payload.appattach && payload.appattach.aeskey}</aeskey>
 			<encryver>${payload.appattach && payload.appattach.encryver}</encryver>
@@ -105,16 +100,9 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 		<template_id />
 		<md5>${payload.md5 || ''}</md5>
 		<weappinfo>
-			<username><![CDATA[${payload.weappinfo && payload.weappinfo.username}]]</username>
-			<appid><![CDATA[${payload.weappinfo && payload.weappinfo.appid}]]</appid>
-			<pagepath><![CDATA[${payload.weappinfo && payload.weappinfo.pagepath}]]</pagepath>
-			<version>${payload.weappinfo && payload.weappinfo.version}</version>
-			<weappiconurl><![CDATA[${payload.weappinfo && payload.weappinfo.weappiconurl}]]</weappiconurl>
+			<username />
+			<appid />
 			<appservicetype>0</appservicetype>
-			<pkginfo>
-				<type>${payload.weappinfo && payload.weappinfo.pkginfo && payload.weappinfo.pkginfo.type}</type>
-				<md5><![CDATA[${payload.weappinfo && payload.weappinfo.pkginfo && payload.weappinfo.pkginfo.md5}]]></md5>
-			</pkginfo>
 			<videopageinfo>
 				<thumbwidth>0</thumbwidth>
 				<thumbheight>0</thumbheight>
@@ -131,8 +119,8 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 	<fromusername>${payload.fromusername}</fromusername>
 	<scene>0</scene>
 	<appinfo>
-		<version>${payload.appinfo && payload.appinfo.version || '1'}</version>
-		<appname>${payload.appinfo && payload.appinfo.appname}</appname>
+		<version>1</version>
+		<appname></appname>
 	</appinfo>
 	<commenturl></commenturl>`
 }

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -1,5 +1,16 @@
 import { UrlLinkPayload } from 'wechaty-puppet'
-import { PadproAppMessagePayload, WechatAppMessageType } from '../schemas'
+import { PadproAppMessagePayload, WechatAppMessageType, PadproLocationMessagePayload } from '../schemas'
+
+export const generateLocationMessage = (payload: PadproLocationMessagePayload): string => {
+  return `<location x="${payload.x || ''}"` +
+                  ` y="${payload.y || ''}"` +
+                  ` scale="${payload.scale || ''}"` +
+                  ` label="${payload.label || ''}"` +
+                  ` maptype="${payload.mapType || ''}"` +
+                  ` poiname="${payload.poiName || ''}"` +
+                  ` poiid="${payload.poiId || ''}"` +
+                  ` fromusername="${payload.fromUsername || ''}" />`
+}
 
 export const generateAppXMLMessage = ({ title, description, url, thumbnailUrl }: UrlLinkPayload): string => {
   return '' +

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -87,7 +87,7 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 			<publisherId />
 		</webviewshared>
 		<template_id />
-		<md5>${payload.md5}</md5>
+		<md5>${payload.md5 || ''}</md5>
 		<weappinfo>
 			<username />
 			<appid />
@@ -98,7 +98,8 @@ export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePay
 				<fromopensdk>0</fromopensdk>
 			</videopageinfo>
 		</weappinfo>
-		<statextstr />
+    <statextstr />
+    <recorditem><![CDATA[${payload.recorditem || ''}]]></recorditem>
 		<websearch>
 			<rec_category>0</rec_category>
 			<channelId>0</channelId>

--- a/src/pure-function-helpers/app-message-generator.ts
+++ b/src/pure-function-helpers/app-message-generator.ts
@@ -19,38 +19,96 @@ export const generateAppXMLMessage = ({ title, description, url, thumbnailUrl }:
 
 export const generateAttachmentXMLMessageFromRaw = (payload: PadproAppMessagePayload): string => {
   return `
-  <appmsg appid="" sdkver="0">
-    <title>${payload.title}</title>
-    <des></des>
-    <action></action>
-    <type>${payload.type}</type>
-    <showtype>0</showtype>
-    <mediatagname></mediatagname>
-    <messageaction></messageaction>
-    <content></content>
-    <url></url>
-    <lowurl></lowurl>
-    <dataurl></dataurl>
-    <lowdataurl></lowdataurl>
-    <appattach>
-      <totallen>${payload.appattach && payload.appattach.totallen}</totallen>
-      <attachid>
-        ${payload.appattach && payload.appattach.attachid}
-      </attachid>
-      <emoticonmd5></emoticonmd5>
-      <fileext>${payload.appattach && payload.appattach.fileext}</fileext>
-      <cdnattachurl>
-        ${payload.appattach && payload.appattach.cdnattachurl}
-      </cdnattachurl>
-      <aeskey>${payload.appattach && payload.appattach.aeskey}</aeskey>
-      <encryver>${payload.appattach && payload.appattach.encryver}</encryver>
-    </appattach>
-    <extinfo></extinfo>
-    <sourceusername></sourceusername>
-    <sourcedisplayname></sourcedisplayname>
-    <commenturl></commenturl>
-    <thumburl></thumburl>
-    <md5>${payload.md5}</md5>
-  </appmsg>
-  `
+	<appmsg appid="" sdkver="0">
+		<title>${payload.title}</title>
+		<des></des>
+		<username />
+		<action>view</action>
+		<type>${payload.type}</type>
+		<showtype>0</showtype>
+		<content />
+		<url />
+		<lowurl />
+		<dataurl />
+		<lowdataurl />
+		<contentattr>0</contentattr>
+		<streamvideo>
+			<streamvideourl />
+			<streamvideototaltime>0</streamvideototaltime>
+			<streamvideotitle />
+			<streamvideowording />
+			<streamvideoweburl />
+			<streamvideothumburl />
+			<streamvideoaduxinfo />
+			<streamvideopublishid />
+		</streamvideo>
+		<canvasPageItem>
+			<canvasPageXml><![CDATA[]]></canvasPageXml>
+		</canvasPageItem>
+		<appattach>
+			<attachid>${payload.appattach && payload.appattach.attachid}</attachid>
+			<cdnattachurl>${payload.appattach && payload.appattach.cdnattachurl}</cdnattachurl>
+			<totallen>${payload.appattach && payload.appattach.totallen}</totallen>
+			<aeskey>${payload.appattach && payload.appattach.aeskey}</aeskey>
+			<encryver>${payload.appattach && payload.appattach.encryver}</encryver>
+			<fileext>${payload.appattach && payload.appattach.fileext}</fileext>
+			<islargefilemsg>${payload.appattach && payload.appattach.islargefilemsg}</islargefilemsg>
+		</appattach>
+		<extinfo />
+		<thumburl />
+		<mediatagname />
+		<messageaction><![CDATA[]]></messageaction>
+		<messageext><![CDATA[]]></messageext>
+		<emoticongift>
+			<packageflag>0</packageflag>
+			<packageid />
+		</emoticongift>
+		<emoticonshared>
+			<packageflag>0</packageflag>
+			<packageid />
+		</emoticonshared>
+		<designershared>
+			<designeruin>0</designeruin>
+			<designername>null</designername>
+			<designerrediretcturl>null</designerrediretcturl>
+		</designershared>
+		<emotionpageshared>
+			<tid>0</tid>
+			<title>null</title>
+			<desc>null</desc>
+			<iconUrl>null</iconUrl>
+			<secondUrl>null</secondUrl>
+			<pageType>0</pageType>
+		</emotionpageshared>
+		<webviewshared>
+			<shareUrlOriginal />
+			<shareUrlOpen />
+			<jsAppId />
+			<publisherId />
+		</webviewshared>
+		<template_id />
+		<md5>${payload.md5}</md5>
+		<weappinfo>
+			<username />
+			<appid />
+			<appservicetype>0</appservicetype>
+			<videopageinfo>
+				<thumbwidth>0</thumbwidth>
+				<thumbheight>0</thumbheight>
+				<fromopensdk>0</fromopensdk>
+			</videopageinfo>
+		</weappinfo>
+		<statextstr />
+		<websearch>
+			<rec_category>0</rec_category>
+			<channelId>0</channelId>
+		</websearch>
+	</appmsg>
+	<fromusername>${payload.fromusername}</fromusername>
+	<scene>0</scene>
+	<appinfo>
+		<version>1</version>
+		<appname></appname>
+	</appinfo>
+	<commenturl></commenturl>`
 }

--- a/src/pure-function-helpers/message-app-payload-parser.spec.ts
+++ b/src/pure-function-helpers/message-app-payload-parser.spec.ts
@@ -7,7 +7,7 @@ import { appMessageParser } from '.'
 import { PadproMessagePayload } from '../schemas'
 
 const sampleLink: PadproMessagePayload = {
-  content: '<msg><appmsg appid=\"\" sdkver=\"0\"><title>全球最惨烈的房地产泡沫，是怎么滋生、膨胀、破灭的？</title><des>十次危机九次地产，过去一百年有四次波澜壮阔的房地产危机，每一次都影响深远，猫哥打算分两期跟大家回顾这四次地产危机，个中滋味各自体会。</des><action></action><type>5</type><showtype>0</showtype><soundtype>0</soundtype><mediatagname></mediatagname><messageext></messageext><messageaction></messageaction><content></content><contentattr>0</contentattr><url>http://mp.weixin.qq.com/s?__biz=MjM5MDY5NjI2MQ==&amp;mid=2649758936&amp;idx=1&amp;sn=57c792c972163c93331c4e5daefe81d3&amp;chksm=be446af28933e3e4a98dc8478cb72e43269dafefaa0241f5a2863d12540d37d56afff48f8617&amp;mpshare=1&amp;scene=1&amp;srcid=0807oacxSyqTqFVtuXlErueP#rd</url><lowurl></lowurl><dataurl></dataurl><lowdataurl></lowdataurl><appattach><totallen>0</totallen><attachid></attachid><emoticonmd5></emoticonmd5><fileext></fileext><cdnthumburl>3059020100045230500201000204300cad8c02033d0af802047030feb602045b68dd6a042b777875706c6f61645f373032313533303331334063686174726f6f6d333835385f313533333539393038310204010400030201000400</cdnthumburl><cdnthumbmd5>2e2b8a1ace12ecf482119868ebf0eb85</cdnthumbmd5><cdnthumblength>5270</cdnthumblength><cdnthumbwidth>160</cdnthumbwidth><cdnthumbheight>160</cdnthumbheight><cdnthumbaeskey>fe3ba55a0eec46cd8e66e6ae08f1c5e6</cdnthumbaeskey><aeskey>fe3ba55a0eec46cd8e66e6ae08f1c5e6</aeskey><encryver>0</encryver><filekey>wxid_rdwh63c150bm12182_1533627050</filekey></appattach><extinfo></extinfo><sourceusername>gh_315ad8d1dc77</sourceusername><sourcedisplayname>大猫财经</sourcedisplayname><thumburl>http://mmbiz.qpic.cn/mmbiz_jpg/tft1HVJPPk9BOD3thBicXAzZpO117gbtVy8lhB7Pn3nsZtU7ydhUJQZdT33HEvnQynJgsib93JXbs1jBKjkMAJJA/300?wx_fmt=jpeg&amp;wxfrom=1</thumburl><md5></md5><statextstr></statextstr></appmsg><fromusername>lylezhuifeng</fromusername><scene>0</scene><appinfo><version>1</version><appname></appname></appinfo><commenturl></commenturl></msg>',
+  content: '<msg><appmsg appid=\"\" sdkver=\"0\"><title>全球最惨烈的房地产泡沫，是怎么滋生、膨胀、破灭的？</title><des>十次危机九次地产，过去一百年有四次波澜壮阔的房地产危机，每一次都影响深远，猫哥打算分两期跟大家回顾这四次地产危机，个中滋味各自体会。</des><action></action><type>5</type><showtype>0</showtype><soundtype>0</soundtype><mediatagname></mediatagname><messageext></messageext><messageaction></messageaction><content></content><contentattr>0</contentattr><url>http://mp.weixin.qq.com/s?__biz=MjM5MDY5NjI2MQ==&amp;mid=2649758936&amp;idx=1&amp;sn=57c792c972163c93331c4e5daefe81d3&amp;chksm=be446af28933e3e4a98dc8478cb72e43269dafefaa0241f5a2863d12540d37d56afff48f8617&amp;mpshare=1&amp;scene=1&amp;srcid=0807oacxSyqTqFVtuXlErueP#rd</url><lowurl></lowurl><dataurl></dataurl><lowdataurl></lowdataurl><appattach><totallen>0</totallen><attachid></attachid><emoticonmd5></emoticonmd5><fileext></fileext><cdnthumburl>3059020100045230500201000204300cad8c02033d0af802047030feb602045b68dd6a042b777875706c6f61645f373032313533303331334063686174726f6f6d333835385f313533333539393038310204010400030201000400</cdnthumburl><cdnthumbmd5>2e2b8a1ace12ecf482119868ebf0eb85</cdnthumbmd5><cdnthumblength>5270</cdnthumblength><cdnthumbwidth>160</cdnthumbwidth><cdnthumbheight>160</cdnthumbheight><cdnthumbaeskey>fe3ba55a0eec46cd8e66e6ae08f1c5e6</cdnthumbaeskey><aeskey>fe3ba55a0eec46cd8e66e6ae08f1c5e6</aeskey><encryver>0</encryver><filekey>wxid_rdwh63c150bm12182_1533627050</filekey><islargefilemsg>0</islargefilemsg></appattach><extinfo></extinfo><sourceusername>gh_315ad8d1dc77</sourceusername><sourcedisplayname>大猫财经</sourcedisplayname><thumburl>http://mmbiz.qpic.cn/mmbiz_jpg/tft1HVJPPk9BOD3thBicXAzZpO117gbtVy8lhB7Pn3nsZtU7ydhUJQZdT33HEvnQynJgsib93JXbs1jBKjkMAJJA/300?wx_fmt=jpeg&amp;wxfrom=1</thumburl><md5></md5><statextstr></statextstr></appmsg><fromusername>lylezhuifeng</fromusername><scene>0</scene><appinfo><version>1</version><appname></appname></appinfo><commenturl></commenturl></msg>',
   fromUser: 'lylezhuifeng',
   messageId: '8273769814016020343',
   messageSource: '<msgsource />\n',
@@ -325,22 +325,24 @@ const sampleLink: PadproMessagePayload = {
 test('Should be able to parse url link message successfully', async (t) => {
   const payload = await appMessageParser(sampleLink)
   const expectedResult = {
-    md5: '',
     title: '全球最惨烈的房地产泡沫，是怎么滋生、膨胀、破灭的？',
     des: '十次危机九次地产，过去一百年有四次波澜壮阔的房地产危机，每一次都影响深远，猫哥打算分两期跟大家回顾这四次地产危机，个中滋味各自体会。',
     url: 'http://mp.weixin.qq.com/s?__biz=MjM5MDY5NjI2MQ==&mid=2649758936&idx=1&sn=57c792c972163c93331c4e5daefe81d3&chksm=be446af28933e3e4a98dc8478cb72e43269dafefaa0241f5a2863d12540d37d56afff48f8617&mpshare=1&scene=1&srcid=0807oacxSyqTqFVtuXlErueP#rd',
     thumburl: 'http://mmbiz.qpic.cn/mmbiz_jpg/tft1HVJPPk9BOD3thBicXAzZpO117gbtVy8lhB7Pn3nsZtU7ydhUJQZdT33HEvnQynJgsib93JXbs1jBKjkMAJJA/300?wx_fmt=jpeg&wxfrom=1',
+    md5: '',
     type: 5,
     appattach: {
       aeskey: 'fe3ba55a0eec46cd8e66e6ae08f1c5e6',
       attachid: '',
-      cdnthumbaeskey: 'fe3ba55a0eec46cd8e66e6ae08f1c5e6',
       cdnattachurl: undefined,
+      cdnthumbaeskey: 'fe3ba55a0eec46cd8e66e6ae08f1c5e6',
       emoticonmd5: '',
       encryver: 0,
       fileext: '',
-      totallen: 0
-    }
+      totallen: 0,
+      islargefilemsg: 0
+    },
+    recorditem: undefined
   }
   t.deepEqual(payload, expectedResult)
 })

--- a/src/pure-function-helpers/message-app-payload-parser.ts
+++ b/src/pure-function-helpers/message-app-payload-parser.ts
@@ -32,7 +32,8 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
           cdnattachurl: string,
           cdnthumbaeskey: string,
           aeskey: string,
-          encryver: string
+          encryver: string,
+          islargefilemsg: string,
         },
         thumburl: string,
         md5: any,
@@ -63,6 +64,7 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         encryver      : parseInt(tmp.encryver, 10),
         fileext       : tmp.fileext,
         totallen      : parseInt(tmp.totallen, 10),
+        islargefilemsg: parseInt(tmp.islargefilemsg, 10),
       }
     }
     return { title, des, url, thumburl, md5, type: parseInt(type, 10), appattach }

--- a/src/pure-function-helpers/message-app-payload-parser.ts
+++ b/src/pure-function-helpers/message-app-payload-parser.ts
@@ -20,10 +20,6 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
   interface XmlSchema {
     msg: {
       appmsg: {
-        $: {
-          appid: string,
-          sdkver: string,
-        },
         title: string,
         des: string,
         type: string,
@@ -34,37 +30,18 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
           emoticonmd5: string,
           fileext: string,
           cdnattachurl: string,
-          cdnthumburl: string,
-          cdnthumbmd5: string,
-          cdnthumblength: string,
-          cdnthumbwidth: string,
-          cdnthumbheight: string,
           cdnthumbaeskey: string,
           aeskey: string,
           encryver: string,
           islargefilemsg: string,
-          // filekey: string,
         },
-        statextstr: string,
         thumburl: string,
         md5: any,
-        recorditem?: string,
-        weappinfo?: {
-          username: string,
-          appid: string,
-          pagepath: string,
-          version: string,
-          weappiconurl: string,
-          pkginfo?: {
-            type: string,
-            md5: string,
-          },
-        },
+        recorditem?: string
       },
       fromusername: string,
       appinfo: {
-        appname: string,
-        version: string,
+        appname: any
       }
     }
   }
@@ -74,8 +51,7 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
   try {
     const jsonPayload: XmlSchema = await xmlToJson(tryXmlText)
 
-    const { appinfo } = jsonPayload.msg;
-    const { title, des, url, thumburl, type, md5, recorditem, weappinfo } = jsonPayload.msg.appmsg
+    const { title, des, url, thumburl, type, md5, recorditem } = jsonPayload.msg.appmsg
     let appattach: PadproAppAttachPayload | undefined
     const tmp = jsonPayload.msg.appmsg.appattach
     if (tmp) {
@@ -83,11 +59,6 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         aeskey        : tmp.aeskey,
         attachid      : tmp.attachid,
         cdnattachurl  : tmp.cdnattachurl,
-        cdnthumburl   : tmp.cdnthumburl,
-        cdnthumbmd5   : tmp.cdnthumbmd5,
-        cdnthumblength: tmp.cdnthumblength,
-        cdnthumbwidth : tmp.cdnthumbwidth,
-        cdnthumbheight: tmp.cdnthumbheight,
         cdnthumbaeskey: tmp.cdnthumbaeskey,
         emoticonmd5   : tmp.emoticonmd5,
         encryver      : parseInt(tmp.encryver, 10),
@@ -96,19 +67,7 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         islargefilemsg: parseInt(tmp.islargefilemsg, 10),
       }
     }
-    return {
-      $appid: jsonPayload.msg.appmsg.$.appid,
-      title,
-      des,
-      url,
-      thumburl,
-      md5,
-      type: parseInt(type, 10),
-      appattach,
-      recorditem,
-      weappinfo,
-      appinfo,
-    }
+    return { title, des, url, thumburl, md5, type: parseInt(type, 10), appattach, recorditem }
   } catch (e) {
     log.verbose(e.stack)
     return null

--- a/src/pure-function-helpers/message-app-payload-parser.ts
+++ b/src/pure-function-helpers/message-app-payload-parser.ts
@@ -51,7 +51,7 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
   try {
     const jsonPayload: XmlSchema = await xmlToJson(tryXmlText)
 
-    const { title, des, url, thumburl, type, md5 } = jsonPayload.msg.appmsg
+    const { title, des, url, thumburl, type, md5, recorditem } = jsonPayload.msg.appmsg
     let appattach: PadproAppAttachPayload | undefined
     const tmp = jsonPayload.msg.appmsg.appattach
     if (tmp) {
@@ -67,7 +67,7 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         islargefilemsg: parseInt(tmp.islargefilemsg, 10),
       }
     }
-    return { title, des, url, thumburl, md5, type: parseInt(type, 10), appattach }
+    return { title, des, url, thumburl, md5, type: parseInt(type, 10), appattach, recorditem }
   } catch (e) {
     log.verbose(e.stack)
     return null

--- a/src/pure-function-helpers/message-app-payload-parser.ts
+++ b/src/pure-function-helpers/message-app-payload-parser.ts
@@ -20,6 +20,10 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
   interface XmlSchema {
     msg: {
       appmsg: {
+        $: {
+          appid: string,
+          sdkver: string,
+        },
         title: string,
         des: string,
         type: string,
@@ -30,18 +34,37 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
           emoticonmd5: string,
           fileext: string,
           cdnattachurl: string,
+          cdnthumburl: string,
+          cdnthumbmd5: string,
+          cdnthumblength: string,
+          cdnthumbwidth: string,
+          cdnthumbheight: string,
           cdnthumbaeskey: string,
           aeskey: string,
           encryver: string,
           islargefilemsg: string,
+          // filekey: string,
         },
+        statextstr: string,
         thumburl: string,
         md5: any,
-        recorditem?: string
+        recorditem?: string,
+        weappinfo?: {
+          username: string,
+          appid: string,
+          pagepath: string,
+          version: string,
+          weappiconurl: string,
+          pkginfo?: {
+            type: string,
+            md5: string,
+          },
+        },
       },
       fromusername: string,
       appinfo: {
-        appname: any
+        appname: string,
+        version: string,
       }
     }
   }
@@ -51,7 +74,8 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
   try {
     const jsonPayload: XmlSchema = await xmlToJson(tryXmlText)
 
-    const { title, des, url, thumburl, type, md5, recorditem } = jsonPayload.msg.appmsg
+    const { appinfo } = jsonPayload.msg;
+    const { title, des, url, thumburl, type, md5, recorditem, weappinfo } = jsonPayload.msg.appmsg
     let appattach: PadproAppAttachPayload | undefined
     const tmp = jsonPayload.msg.appmsg.appattach
     if (tmp) {
@@ -59,6 +83,11 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         aeskey        : tmp.aeskey,
         attachid      : tmp.attachid,
         cdnattachurl  : tmp.cdnattachurl,
+        cdnthumburl   : tmp.cdnthumburl,
+        cdnthumbmd5   : tmp.cdnthumbmd5,
+        cdnthumblength: tmp.cdnthumblength,
+        cdnthumbwidth : tmp.cdnthumbwidth,
+        cdnthumbheight: tmp.cdnthumbheight,
         cdnthumbaeskey: tmp.cdnthumbaeskey,
         emoticonmd5   : tmp.emoticonmd5,
         encryver      : parseInt(tmp.encryver, 10),
@@ -67,7 +96,19 @@ export async function appMessageParser (rawPayload: PadproMessagePayload): Promi
         islargefilemsg: parseInt(tmp.islargefilemsg, 10),
       }
     }
-    return { title, des, url, thumburl, md5, type: parseInt(type, 10), appattach, recorditem }
+    return {
+      $appid: jsonPayload.msg.appmsg.$.appid,
+      title,
+      des,
+      url,
+      thumburl,
+      md5,
+      type: parseInt(type, 10),
+      appattach,
+      recorditem,
+      weappinfo,
+      appinfo,
+    }
   } catch (e) {
     log.verbose(e.stack)
     return null

--- a/src/pure-function-helpers/message-location-payload-parser.ts
+++ b/src/pure-function-helpers/message-location-payload-parser.ts
@@ -1,0 +1,53 @@
+import { PadproLocationMessagePayload, PadproMessagePayload } from '../schemas'
+import { isPayload } from './is-type'
+import { xmlToJson } from './xml-to-json'
+
+export async function locationPayloadParser (rawPayload: PadproMessagePayload): Promise<PadproLocationMessagePayload | null> {
+  if (!isPayload(rawPayload)) {
+    return null
+  }
+
+  const { content } = rawPayload
+
+  // TODO: put the json payload here in comments
+
+  interface XmlSchema {
+    msg: {
+      location: {
+        $: {
+          x: string,
+          y: string,
+          scale: string,
+          label: string,
+          maptype: string,
+          poiname: string,
+          poiid: string,
+          fromusername: string,
+        }
+      }
+    }
+  }
+
+  const tryXmlText = content.replace(/^[^\n]+\n/, '')
+
+  try {
+    const jsonPayload: XmlSchema = await xmlToJson(tryXmlText)
+
+    const data = jsonPayload.msg.location.$
+    const result: PadproLocationMessagePayload = {
+      x: parseInt(data.x, 10),
+      y: parseInt(data.y, 10),
+      scale: parseInt(data.scale, 10),
+      label: data.label,
+      mapType: parseInt(data.maptype, 10),
+      poiName: data.poiname,
+      poiId: data.poiid,
+      fromUsername: data.fromusername,
+    }
+
+    return result
+  } catch (e) {
+    console.error(e)
+    return null
+  }
+}

--- a/src/pure-function-helpers/message-location-payload-parser.ts
+++ b/src/pure-function-helpers/message-location-payload-parser.ts
@@ -35,11 +35,11 @@ export async function locationPayloadParser (rawPayload: PadproMessagePayload): 
 
     const data = jsonPayload.msg.location.$
     const result: PadproLocationMessagePayload = {
-      x: parseInt(data.x, 10),
-      y: parseInt(data.y, 10),
+      x: parseFloat(data.x),
+      y: parseFloat(data.y),
       scale: parseInt(data.scale, 10),
       label: data.label,
-      mapType: parseInt(data.maptype, 10),
+      mapType: data.maptype,
       poiName: data.poiname,
       poiId: data.poiid,
       fromUsername: data.fromusername,

--- a/src/pure-function-helpers/message-raw-payload-parser.ts
+++ b/src/pure-function-helpers/message-raw-payload-parser.ts
@@ -244,7 +244,6 @@ export async function messageRawPayloadParser (
           payload.type = MessageType.ChatHistory
           break
         case WechatAppMessageType.MiniProgram:
-        case WechatAppMessageType.MiniProgramApp:
           payload.type = MessageType.MiniProgram
           break
         case WechatAppMessageType.RedEnvelopes:

--- a/src/pure-function-helpers/message-raw-payload-parser.ts
+++ b/src/pure-function-helpers/message-raw-payload-parser.ts
@@ -244,6 +244,7 @@ export async function messageRawPayloadParser (
           payload.type = MessageType.ChatHistory
           break
         case WechatAppMessageType.MiniProgram:
+        case WechatAppMessageType.MiniProgramApp:
           payload.type = MessageType.MiniProgram
           break
         case WechatAppMessageType.RedEnvelopes:

--- a/src/pure-function-helpers/message-raw-payload-parser.ts
+++ b/src/pure-function-helpers/message-raw-payload-parser.ts
@@ -27,6 +27,12 @@ import {
   messageType,
 }                         from './message-type'
 
+import {
+  log,
+}                         from '../config'
+
+const PRE = 'messageRawPayloadParser'
+
 export async function messageRawPayloadParser (
   rawPayload: PadproMessagePayload,
 ): Promise<MessagePayload> {
@@ -37,6 +43,7 @@ export async function messageRawPayloadParser (
    * 0. Set Message Type
    */
   const type = messageType(rawPayload.messageType)
+  log.silly(PRE, `messageType ${type}`)
 
   const payloadBase = {
     id        : rawPayload.messageId,
@@ -231,6 +238,7 @@ export async function messageRawPayloadParser (
           break
         case WechatAppMessageType.Attach:
           payload.type = MessageType.Attachment
+          payload.filename = appPayload.title
           break
         case WechatAppMessageType.ChatHistory:
           payload.type = MessageType.ChatHistory

--- a/src/pure-function-helpers/message-type.ts
+++ b/src/pure-function-helpers/message-type.ts
@@ -37,6 +37,11 @@ export function messageType (
       // console.log(rawPayload)
       break
 
+    case PadproMessageType.Location:
+      type = MessageType.Location
+      // console.log(rawPayload)
+      break
+
     case PadproMessageType.Video:
       type = MessageType.Video
       // console.log(rawPayload)

--- a/src/schemas/padpro-enums.ts
+++ b/src/schemas/padpro-enums.ts
@@ -100,7 +100,6 @@ export enum WechatAppMessageType {
   RealtimeShareLocation = 17,
   ChatHistory           = 19,
   MiniProgram           = 33,
-  MiniProgramApp        = 36,  // this is forwardable mini program
   Transfers             = 2000,
   RedEnvelopes          = 2001,
   ReaderType            = 100001,

--- a/src/schemas/padpro-enums.ts
+++ b/src/schemas/padpro-enums.ts
@@ -100,6 +100,7 @@ export enum WechatAppMessageType {
   RealtimeShareLocation = 17,
   ChatHistory           = 19,
   MiniProgram           = 33,
+  MiniProgramApp        = 36,  // this is forwardable mini program
   Transfers             = 2000,
   RedEnvelopes          = 2001,
   ReaderType            = 100001,

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -164,13 +164,14 @@ export interface PadproRoomInvitationPayload {
 }
 
 export interface PadproAppMessagePayload {
-  des?      : string,
-  thumburl? : string,
-  title     : string,
-  url       : string,
-  appattach?: PadproAppAttachPayload,
-  type      : WechatAppMessageType,
-  md5?      : string,
+  des?          : string,
+  thumburl?     : string,
+  title         : string,
+  url           : string,
+  appattach?    : PadproAppAttachPayload,
+  type          : WechatAppMessageType,
+  md5?          : string,
+  fromusername? : string,
 }
 
 export interface PadproAppAttachPayload {
@@ -182,6 +183,7 @@ export interface PadproAppAttachPayload {
   aeskey?        : string,
   cdnthumbaeskey?: string,
   encryver?      : number,
+  islargefilemsg : number,
 }
 
 export interface PadproEmojiMessagePayload {

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -164,6 +164,7 @@ export interface PadproRoomInvitationPayload {
 }
 
 export interface PadproAppMessagePayload {
+  $appid?       : string,
   des?          : string,
   thumburl?     : string,
   title         : string,
@@ -173,6 +174,13 @@ export interface PadproAppMessagePayload {
   md5?          : string,
   fromusername? : string,
   recorditem?   : string,
+  weappinfo?    : PadproWeAppInfoPayload,
+  appinfo?      : PadproAppInfoPayload,
+}
+
+export interface PadproAppInfoPayload {
+  version: string,
+  appname: string,
 }
 
 export interface PadproAppAttachPayload {
@@ -180,11 +188,28 @@ export interface PadproAppAttachPayload {
   attachid?      : string,
   emoticonmd5?   : string,
   fileext?       : string,
-  cdnattachurl?  : string,
   aeskey?        : string,
+  cdnattachurl?  : string,
+  cdnthumburl?   : string,
+  cdnthumbmd5?   : string,
+  cdnthumblength?: string,
+  cdnthumbwidth? : string,
+  cdnthumbheight?: string,
   cdnthumbaeskey?: string,
   encryver?      : number,
-  islargefilemsg : number,
+  islargefilemsg?: number,
+}
+
+export interface PadproWeAppInfoPayload {
+  username: string,
+  appid: string,
+  pagepath: string,
+  version: string,
+  weappiconurl: string,
+  pkginfo?: {
+    type: string,
+    md5: string,
+  },
 }
 
 export interface PadproEmojiMessagePayload {

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -234,6 +234,17 @@ export interface PadproVoiceMessagePayload {
   bufId: number,
 }
 
+export interface PadproLocationMessagePayload {
+  x: number,
+  y: number,
+  scale: number,
+  mapType: number,
+  label: string,
+  poiId: string,
+  poiName: string,
+  fromUsername: string,
+}
+
 export interface PadproVideoMessagePayload {
   aesKey: string,
   cdnThumbAesKey: string,

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -172,6 +172,7 @@ export interface PadproAppMessagePayload {
   type          : WechatAppMessageType,
   md5?          : string,
   fromusername? : string,
+  recorditem?   : string,
 }
 
 export interface PadproAppAttachPayload {

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -164,7 +164,6 @@ export interface PadproRoomInvitationPayload {
 }
 
 export interface PadproAppMessagePayload {
-  $appid?       : string,
   des?          : string,
   thumburl?     : string,
   title         : string,
@@ -174,13 +173,6 @@ export interface PadproAppMessagePayload {
   md5?          : string,
   fromusername? : string,
   recorditem?   : string,
-  weappinfo?    : PadproWeAppInfoPayload,
-  appinfo?      : PadproAppInfoPayload,
-}
-
-export interface PadproAppInfoPayload {
-  version: string,
-  appname: string,
 }
 
 export interface PadproAppAttachPayload {
@@ -188,28 +180,11 @@ export interface PadproAppAttachPayload {
   attachid?      : string,
   emoticonmd5?   : string,
   fileext?       : string,
-  aeskey?        : string,
   cdnattachurl?  : string,
-  cdnthumburl?   : string,
-  cdnthumbmd5?   : string,
-  cdnthumblength?: string,
-  cdnthumbwidth? : string,
-  cdnthumbheight?: string,
+  aeskey?        : string,
   cdnthumbaeskey?: string,
   encryver?      : number,
-  islargefilemsg?: number,
-}
-
-export interface PadproWeAppInfoPayload {
-  username: string,
-  appid: string,
-  pagepath: string,
-  version: string,
-  weappiconurl: string,
-  pkginfo?: {
-    type: string,
-    md5: string,
-  },
+  islargefilemsg : number,
 }
 
 export interface PadproEmojiMessagePayload {

--- a/src/schemas/padpro-schemas.ts
+++ b/src/schemas/padpro-schemas.ts
@@ -238,7 +238,7 @@ export interface PadproLocationMessagePayload {
   x: number,
   y: number,
   scale: number,
-  mapType: number,
+  mapType: string,
   label: string,
   poiId: string,
   poiName: string,

--- a/src/utils/cdn-utils.ts
+++ b/src/utils/cdn-utils.ts
@@ -9,6 +9,10 @@ import {
 
 import { packCdnData, unpackCdnData } from '../pure-function-helpers'
 
+import { log } from '../config'
+
+const PRE = 'CDNUtils'
+
 export const packDownloadRequest = (request: CDNDownloadDataRequest): Buffer => {
   return packCdnData(request)
 }
@@ -107,6 +111,9 @@ export const unpackCheckMd5Response = (rawResponse: Buffer): CDNCheckMd5Response
   if (rawRes.cachesize) {
     result.cachesize = parseInt(rawRes.cachesize.toString(), 10)
   }
+
+  log.silly(PRE, `checkMd5Response - ${JSON.stringify(result)}`)
+
   return result
 }
 
@@ -161,18 +168,18 @@ export const unpackUploadRequest = (buf: Buffer): CDNUploadDataRequest => {
 export const unpackUploadResponse = (rawResponse: Buffer): CDNUploadDataResponse => {
   const rawRes = unpackCdnData(rawResponse)
   const result: CDNUploadDataResponse = {
-    'ver': parseInt(rawRes.ver.toString(), 10),
-    'filekey': rawRes.filekey.toString(),
-    'rangestart': parseInt(rawRes.rangestart.toString(), 10),
-    'rangeend': parseInt(rawRes.rangeend.toString(), 10),
-    'seq': parseInt(rawRes.seq.toString(), 10),
-    'retcode': parseInt(rawRes.retcode.toString(), 10),
-    'existflag': parseInt(rawRes.existflag.toString(), 10),
-    'retrysec': parseInt(rawRes.retrysec.toString(), 10),
-    'isretry': parseInt(rawRes.isretry.toString(), 10),
-    'isoverload': parseInt(rawRes.isoverload.toString(), 10),
-    'isgetcdn': parseInt(rawRes.isgetcdn.toString(), 10),
-    'x-ClientIp': rawRes['x-ClientIp'].toString(),
+    'ver': rawRes.ver && parseInt(rawRes.ver.toString(), 10),
+    'filekey': rawRes.filekey && rawRes.filekey.toString(),
+    'rangestart': rawRes.rangestart && parseInt(rawRes.rangestart.toString(), 10),
+    'rangeend': rawRes.rangeend && parseInt(rawRes.rangeend.toString(), 10),
+    'seq': rawRes.seq && parseInt(rawRes.seq.toString(), 10),
+    'retcode': rawRes.retcode && parseInt(rawRes.retcode.toString(), 10),
+    'existflag': rawRes.retrysec && parseInt(rawRes.existflag.toString(), 10),
+    'retrysec': rawRes.retrysec && parseInt(rawRes.retrysec.toString(), 10),
+    'isretry': rawRes.isretry && parseInt(rawRes.isretry.toString(), 10),
+    'isoverload': rawRes.isoverload && parseInt(rawRes.isoverload.toString(), 10),
+    'isgetcdn': rawRes.isgetcdn && parseInt(rawRes.isgetcdn.toString(), 10),
+    'x-ClientIp': rawRes['x-ClientIp'] && rawRes['x-ClientIp'].toString(),
   }
   if (rawRes.fileid) {
     result.fileid = rawRes.fileid.toString()


### PR DESCRIPTION
My goal is to resolve #76 


So `forwardAttachment()` wasn't working because of the XML format is changed. I am putting in the new format.

Also found some issues with CDN upload mechanism. Apparently if the file exists in the CDN, one cannot simply re-upload with the same fileId with a newly calculated AES key. So when we download an incoming file from the CDN, we actually need to store the file with AES key in the cache, so when we re-upload the same file, it can get the correct AES key (this part is not done).

我发现CDN有个问题 下载过的文件是不能重新上传的 因为现在AESkey是重新生成的 会被覆盖 但是CDN并不会对同一个ID进行更新

I plan to add more forwarding features, and fix the CDN issue as best as I can (at least storing incoming files into fileCache)