### PR TITLE
Upgrade flash-store from v0.7 to v0.14 (#124)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "array-flatten": "^2.1.1",
     "axios": "^0.18.0",
     "fast-xml-parser": "^3.12.12",
-    "flash-store": "^0.7.1",
+    "flash-store": "^0.14.1",
     "fs-extra": "^8.0.0",
     "google-protobuf": "^3.6.1",
     "grpc": "^1.20.3",

--- a/src/manager/cache-manager.ts
+++ b/src/manager/cache-manager.ts
@@ -323,6 +323,8 @@ export class CacheManager {
       '.wechaty',
       'puppet-padpro-cache',
       path.sep,
+      'flash-store-v0.14',
+      path.sep,
       token,
       path.sep,
       userId,


### PR DESCRIPTION
This PR will solve the problem of incompatible between level-db and rock-db.

The new version will use different cache dir, so there will not be any problem for the end users.